### PR TITLE
Fix cyclic updates

### DIFF
--- a/controllers/clustersecret_controller.go
+++ b/controllers/clustersecret_controller.go
@@ -29,7 +29,7 @@ import (
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"strings"

--- a/controllers/clustersecret_controller.go
+++ b/controllers/clustersecret_controller.go
@@ -128,11 +128,11 @@ func (r *ClusterSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		clusterSecret.Spec.Data = source.Data
 		_, err = r.createNewSecrets(ctx, clusterSecret, ls, namespaceList)
 		if err != nil {
-			return r.updateClusterSecretStatus(ctx, metav1.ConditionFalse, clusterSecret, "Secrets creation has finished successfully", err)
+			return r.updateClusterSecretStatus(ctx, metav1.ConditionTrue, clusterSecret, fmt.Sprintf("Failed to create Secret: (%s)", err), err)
 		}
 	}
 
-	return r.updateClusterSecretStatus(ctx, metav1.ConditionTrue, clusterSecret, fmt.Sprintf("Failed to create Secret: (%s)", err), nil)
+	return r.updateClusterSecretStatus(ctx, metav1.ConditionFalse, clusterSecret, "Secrets creation has finished successfully", nil)
 }
 
 func (r *ClusterSecretReconciler) updateClusterSecretStatus(ctx context.Context, status metav1.ConditionStatus, clusterSecret *v12.ClusterSecret, msg string, err error) (ctrl.Result, error) {
@@ -154,7 +154,7 @@ func (r *ClusterSecretReconciler) createNewSecrets(ctx context.Context, clusterS
 	var secretList []*v1.Secret
 	log.Info("Processing the cluster secret", "clusterSecret.Namespace", clusterSecret.Namespace, "clusterSecret.Name", clusterSecret.Name)
 	for _, n := range namespaceList {
-		log.Info("Checking if the secret exists", "secret.Namespace", n, "secret.Name", clusterSecret.Name)
+		log.V(2).Info("Checking if the secret exists", "secret.Namespace", n, "secret.Name", clusterSecret.Name)
 		found := &v1.Secret{}
 		err := r.Get(ctx, types.NamespacedName{
 			Name:      clusterSecret.Name,

--- a/controllers/valuefromsecret_controller.go
+++ b/controllers/valuefromsecret_controller.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"

--- a/controllers/valuefromsecret_controller.go
+++ b/controllers/valuefromsecret_controller.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"time"
 )
 
@@ -43,16 +43,16 @@ type ValueFromSecretReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *ValueFromSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	log := ctrllog.FromContext(ctx)
 
 	secret := &v1.Secret{}
 	err := r.Get(ctx, req.NamespacedName, secret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Log.Info("Secret resource not found. Ignoring since object must be deleted")
+			log.Info("Secret resource not found. Ignoring since object must be deleted", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
 			return ctrl.Result{}, nil
 		}
-		log.Log.Error(err, "Failed to get Secret, requeuing the request")
+		log.Error(err, "Failed to get Secret, requeuing the request", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -68,29 +68,29 @@ func (r *ValueFromSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 	if clusterSecretName == "" {
-		log.Log.Info("The secret %s/%s doesn't have ClusterSecret annotation, skipping it", secret.Namespace, secret.Name)
+		log.Info("The secret doesn't have ClusterSecret annotation, skipping it", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
 		return ctrl.Result{}, nil
 	}
-	log.Log.Info("Starting the update for the ClusterSecret %s, triggered by an update to the secret %s/%s", clusterSecretName, secret.Namespace, secret.Name)
+	log.Info("Starting the update for the ClusterSecret, triggered by an update to the secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name, "clusterSecret.Name", clusterSecretName)
 
 	clusterSecret := &v12.ClusterSecret{}
 	err = r.Get(ctx, types.NamespacedName{Name: clusterSecretName}, clusterSecret)
 	if err != nil {
-		log.Log.Error(err, "Failed to get ClusterSecret %s", clusterSecretName)
+		log.Error(err, "Failed to get ClusterSecret %s", clusterSecretName)
 		return ctrl.Result{}, err
 	}
 	if clusterSecret.Spec.ValueFrom.SecretName != secret.Name || clusterSecret.Spec.ValueFrom.SecretNamespace != secret.Namespace {
-		log.Log.Info("The secret %s/%s is not defined in the ClusterSecret %s ValueFrom, please update the ClusterSecret resource. Requeing the request", secret.Namespace, secret.Name, clusterSecretName)
+		log.Info("The secret is not defined in the ClusterSecret ValueFrom, please update the ClusterSecret resource. Requeing the request", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name, "clusterSecret.Name", clusterSecretName)
 		return ctrl.Result{RequeueAfter: 2 * time.Minute}, err
 	}
 	clusterSecret.Spec.Data = secret.Data
 
 	err = r.Update(ctx, clusterSecret)
 	if err != nil {
-		log.Log.Error(err, "Failed to update ClusterSecret %s", clusterSecretName)
+		log.Error(err, "Failed to update ClusterSecret", "clusterSecret.Name", clusterSecretName)
 		return ctrl.Result{}, err
 	}
-	log.Log.Info("ClusterSecret %s updated successfully", clusterSecretName)
+	log.Info("ClusterSecret updated successfully", "clusterSecret.Name", clusterSecretName)
 
 	return ctrl.Result{}, nil
 }

--- a/main.go
+++ b/main.go
@@ -57,9 +57,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 


### PR DESCRIPTION
Changelog:
- Add validations on both controllers to prevent cyclic updates
- Add event filter to not even process unwanted events like the secrets creation without the proper annotation, and the processing of all the cluster secrets whenever the controller starts running