### PR TITLE
New namespace is not creating new secrets

### DIFF
--- a/controllers/namespaces_controller.go
+++ b/controllers/namespaces_controller.go
@@ -70,6 +70,18 @@ func (r *NamespacesReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	for _, c := range clusterSecrets.Items {
+		list, err := FilterNamespaceList(&v1.NamespaceList{Items: []v1.Namespace{*namespace}}, &c)
+		if err != nil {
+			log.Error(err, "Failed to filter namespace list")
+			continue
+		}
+		if len(list) == 0 {
+			log.Info("Namespace does not match the ClusterSecret filters, skipping the update", "clusterSecret.Name", c.Name)
+			continue
+		}
+		if c.Annotations == nil {
+			c.Annotations = map[string]string{}
+		}
 		now := time.Now()
 		if c.Annotations["chistadata.io/new-namespace-created-at"] != "" {
 			clusterSecretLastUpdateFromNamespace, err := time.Parse(time.RFC3339, c.Annotations["chistadata.io/new-namespace-created-at"])


### PR DESCRIPTION
- Add an exception to clustersecret_controller.go to reconcile when there are changes on new namespace annotation and not only when there are changes on generation
- Add a filter on namespace reconciliation before updating the ClusterSecret to "fail fast" and prevent the clustersecret_controller.go to run the reconciliation and stop at filtering anyway

Fix #7 