### PR TITLE
Upgrade go.mod dependencies to get security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
- Downgrade golang version to 1.21 as 1.23 is not available yet

Related to #10